### PR TITLE
Fix OpenApi 2.x compatibility for Swashbuckle 10.x support

### DIFF
--- a/src/MJCZone.DapperMatic.AspNetCore/Endpoints/DataTypeEndpoints.cs
+++ b/src/MJCZone.DapperMatic.AspNetCore/Endpoints/DataTypeEndpoints.cs
@@ -45,17 +45,6 @@ public static class DataTypeEndpoints
             .WithDescription(
                 "Returns a list of data types available in the specified datasource, including provider-specific types, extensions, and custom types. Use include=customTypes to discover user-defined types from the database."
             )
-            .WithOpenApi(operation =>
-            {
-                var includeParam = operation.Parameters.FirstOrDefault(p => p.Name == "include");
-                if (includeParam != null)
-                {
-                    includeParam.Description =
-                        "Optional parameter to include additional data. Use 'customTypes' to discover user-defined types from the database (PostgreSQL domains, enums, composite types).";
-                    includeParam.Example = new Microsoft.OpenApi.Any.OpenApiString("customTypes");
-                }
-                return operation;
-            })
             .Produces<ProviderDataTypeListResponse>((int)HttpStatusCode.OK)
             .Produces((int)HttpStatusCode.NotFound)
             .Produces((int)HttpStatusCode.Forbidden);

--- a/src/MJCZone.DapperMatic.AspNetCore/Endpoints/TableEndpoints.cs
+++ b/src/MJCZone.DapperMatic.AspNetCore/Endpoints/TableEndpoints.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.OpenApi.Any;
 using MJCZone.DapperMatic.AspNetCore.Extensions;
 using MJCZone.DapperMatic.AspNetCore.Models.Dtos;
 using MJCZone.DapperMatic.AspNetCore.Models.Responses;
@@ -74,17 +73,7 @@ public static class TableEndpoints
             .MapGet("/", isSchemaSpecific ? ListSchemaTablesAsync : ListTablesAsync)
             .WithName($"List{namePrefix}Tables")
             .WithSummary($"Gets all tables for {schemaText}")
-            .WithOpenApi(operation =>
-            {
-                var includeParam = operation.Parameters.FirstOrDefault(p => p.Name == "include");
-                if (includeParam != null)
-                {
-                    includeParam.Description =
-                        "Comma-separated list of fields to include in the response. Use 'columns' to include column definitions, 'indexes' for indexes, 'constraints' for constraints, or '*' to include all fields. By default, only basic table information is returned.";
-                    includeParam.Example = new OpenApiString("columns,indexes");
-                }
-                return operation;
-            })
+            .WithDescription("Use the 'include' query parameter with 'columns', 'indexes', 'constraints', or '*' to include additional details. By default, only basic table information is returned.")
             .Produces<TableListResponse>((int)HttpStatusCode.OK)
             .Produces((int)HttpStatusCode.NotFound)
             .Produces((int)HttpStatusCode.Forbidden);
@@ -94,17 +83,7 @@ public static class TableEndpoints
             .MapGet("/{tableName}", isSchemaSpecific ? GetSchemaTableAsync : GetTableAsync)
             .WithName($"Get{namePrefix}Table")
             .WithSummary($"Gets a table by name from {schemaText}")
-            .WithOpenApi(operation =>
-            {
-                var includeParam = operation.Parameters.FirstOrDefault(p => p.Name == "include");
-                if (includeParam != null)
-                {
-                    includeParam.Description =
-                        "Comma-separated list of fields to include in the response. Use 'columns' to include column definitions, 'indexes' for indexes, 'constraints' for constraints, or '*' to include all fields.";
-                    includeParam.Example = new OpenApiString("columns,indexes,constraints");
-                }
-                return operation;
-            })
+            .WithDescription("Use the 'include' query parameter with 'columns', 'indexes', 'constraints', or '*' to control which details are returned.")
             .Produces<TableResponse>((int)HttpStatusCode.OK)
             .Produces((int)HttpStatusCode.NotFound)
             .Produces((int)HttpStatusCode.Forbidden);

--- a/src/MJCZone.DapperMatic.AspNetCore/Endpoints/ViewEndpoints.cs
+++ b/src/MJCZone.DapperMatic.AspNetCore/Endpoints/ViewEndpoints.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.OpenApi.Any;
 using MJCZone.DapperMatic.AspNetCore.Extensions;
 using MJCZone.DapperMatic.AspNetCore.Models.Dtos;
 using MJCZone.DapperMatic.AspNetCore.Models.Responses;
@@ -75,17 +74,7 @@ public static class ViewEndpoints
             .MapGet("/", isSchemaSpecific ? ListSchemaViewsAsync : ListViewsAsync)
             .WithName($"List{namePrefix}Views")
             .WithSummary($"Gets all views for {schemaText}")
-            .WithOpenApi(operation =>
-            {
-                var includeParam = operation.Parameters.FirstOrDefault(p => p.Name == "include");
-                if (includeParam != null)
-                {
-                    includeParam.Description =
-                        "Comma-separated list of fields to include in the response. Use 'definition' to include view definitions, or '*' to include all fields. By default, definitions are excluded.";
-                    includeParam.Example = new OpenApiString("definition");
-                }
-                return operation;
-            })
+            .WithDescription("Use the 'include' query parameter with 'definition' to include view definitions, or '*' to include all fields. By default, definitions are excluded.")
             .Produces<ViewListResponse>((int)HttpStatusCode.OK)
             .Produces((int)HttpStatusCode.NotFound)
             .Produces((int)HttpStatusCode.Forbidden);
@@ -95,17 +84,7 @@ public static class ViewEndpoints
             .MapGet("/{viewName}", isSchemaSpecific ? GetSchemaViewAsync : GetViewAsync)
             .WithName($"Get{namePrefix}View")
             .WithSummary($"Gets a view by name from {schemaText}")
-            .WithOpenApi(operation =>
-            {
-                var includeParam = operation.Parameters.FirstOrDefault(p => p.Name == "include");
-                if (includeParam != null)
-                {
-                    includeParam.Description =
-                        "Comma-separated list of fields to include in the response. Use 'definition' to include the view definition, or '*' to include all fields. By default, the definition is excluded.";
-                    includeParam.Example = new OpenApiString("definition");
-                }
-                return operation;
-            })
+            .WithDescription("Use the 'include' query parameter with 'definition' to include the view definition, or '*' to include all fields. By default, the definition is excluded.")
             .Produces<ViewResponse>((int)HttpStatusCode.OK)
             .Produces((int)HttpStatusCode.NotFound)
             .Produces((int)HttpStatusCode.Forbidden);

--- a/src/MJCZone.DapperMatic.AspNetCore/Extensions/EndpointExtensions.cs
+++ b/src/MJCZone.DapperMatic.AspNetCore/Extensions/EndpointExtensions.cs
@@ -49,7 +49,7 @@ internal static class EndpointExtensions
     /// <returns>The configured route group.</returns>
     private static RouteGroupBuilder WithDapperMaticConventions(this RouteGroupBuilder group, string tag)
     {
-        return group.WithTags(tag).AddEndpointFilter<DapperMaticExceptionFilter>().WithOpenApi();
+        return group.WithTags(tag).AddEndpointFilter<DapperMaticExceptionFilter>();
     }
 
     /// <summary>

--- a/src/MJCZone.DapperMatic.AspNetCore/MJCZone.DapperMatic.AspNetCore.csproj
+++ b/src/MJCZone.DapperMatic.AspNetCore/MJCZone.DapperMatic.AspNetCore.csproj
@@ -25,6 +25,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JsonFlatFileDataStore" Version="2.4.2" />
+    <!-- v10.x has breaking source generator changes, keep upper bound -->
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.20,10.0)" />
     <PackageReference Include="MySQL.Data" Version="9.4.0" />
     <PackageReference Include="MySqlConnector" Version="2.4.0" />


### PR DESCRIPTION
  Remove WithOpenApi() calls that reference Microsoft.OpenApi types directly,
  which cause TypeLoadException when consumers use Swashbuckle 10.x with
  Microsoft.OpenApi 2.x (OpenApiOperation became IOpenApiOperation).

  Changes:
  - Remove .WithOpenApi(operation => ...) callbacks from endpoint files
  - Remove .WithOpenApi() from EndpointExtensions (also uses OpenApi types internally)
  - Add .WithDescription() to preserve endpoint documentation
  - Remove unused Microsoft.OpenApi.Any using statements
  - Add comment explaining v10.x upper bound constraint

  The version constraint [8.0.20,10.0) remains because Microsoft.AspNetCore.OpenApi
  v10.x has breaking source generator changes. Consumers should use v9.x.

  Endpoints still appear correctly in Swagger UI via Swashbuckle's endpoint
  discovery - WithOpenApi() was only adding supplementary metadata.