### PR TITLE
Use DmOrderedColumn.Parse in attribute processing to support sort dir…

### DIFF
--- a/src/MJCZone.DapperMatic/Models/DmTableFactory.cs
+++ b/src/MJCZone.DapperMatic/Models/DmTableFactory.cs
@@ -665,7 +665,7 @@ public static class DmTableFactory
                 schemaName,
                 tableName,
                 constraintName,
-                [.. cpa.Columns.Select(c => new DmOrderedColumn(c))]
+                [.. cpa.Columns.Select(DmOrderedColumn.Parse)]
             );
 
             // flag the column as part of the primary key
@@ -722,7 +722,7 @@ public static class DmTableFactory
                     schemaName,
                     tableName,
                     constraintName,
-                    [.. uca.Columns.Select(c => new DmOrderedColumn(c))]
+                    [.. uca.Columns.Select(DmOrderedColumn.Parse)]
                 )
             );
 
@@ -757,7 +757,7 @@ public static class DmTableFactory
                     schemaName,
                     tableName,
                     indexName,
-                    [.. cia.Columns.Select(c => new DmOrderedColumn(c))],
+                    [.. cia.Columns.Select(DmOrderedColumn.Parse)],
                     isUnique: cia.IsUnique
                 )
             );

--- a/tests/MJCZone.DapperMatic.Tests/OrderedColumnParseTests.cs
+++ b/tests/MJCZone.DapperMatic.Tests/OrderedColumnParseTests.cs
@@ -1,0 +1,56 @@
+// Copyright 2025 MJCZone Inc.
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Licensed under the GNU Lesser General Public License v3.0 or later.
+// See LICENSE in the project root for license information.
+
+using MJCZone.DapperMatic.Models;
+
+using Xunit.Abstractions;
+
+namespace MJCZone.DapperMatic.Tests;
+
+public class OrderedColumnParseTests : TestBase
+{
+    public OrderedColumnParseTests(ITestOutputHelper output)
+        : base(output) { }
+
+    [Theory]
+    [InlineData("date", "date", DmColumnOrder.Ascending)]
+    [InlineData("date DESC", "date", DmColumnOrder.Descending)]
+    [InlineData("date ASC", "date", DmColumnOrder.Ascending)]
+    [InlineData("date desc", "date", DmColumnOrder.Descending)]
+    [InlineData("date Asc", "date", DmColumnOrder.Ascending)]
+    [InlineData("my_column", "my_column", DmColumnOrder.Ascending)]
+    [InlineData("my_column DESC", "my_column", DmColumnOrder.Descending)]
+    public void Parse_returns_correct_column_name_and_order(
+        string input,
+        string expectedColumnName,
+        DmColumnOrder expectedOrder
+    )
+    {
+        var result = DmOrderedColumn.Parse(input);
+
+        Assert.Equal(expectedColumnName, result.ColumnName);
+        Assert.Equal(expectedOrder, result.Order);
+    }
+
+    [Theory]
+    [InlineData("  date   DESC  ", "date", DmColumnOrder.Descending)]
+    [InlineData("  col_a  ", "col_a", DmColumnOrder.Ascending)]
+    public void Parse_handles_extra_whitespace(string input, string expectedColumnName, DmColumnOrder expectedOrder)
+    {
+        var result = DmOrderedColumn.Parse(input);
+
+        Assert.Equal(expectedColumnName, result.ColumnName);
+        Assert.Equal(expectedOrder, result.Order);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void Parse_throws_on_null_or_empty(string? input)
+    {
+        Assert.Throws<ArgumentException>(() => DmOrderedColumn.Parse(input!));
+    }
+}

--- a/tests/MJCZone.DapperMatic.Tests/TableFactoryOrderedColumnTests.cs
+++ b/tests/MJCZone.DapperMatic.Tests/TableFactoryOrderedColumnTests.cs
@@ -1,0 +1,106 @@
+// Copyright 2025 MJCZone Inc.
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Licensed under the GNU Lesser General Public License v3.0 or later.
+// See LICENSE in the project root for license information.
+
+using MJCZone.DapperMatic.DataAnnotations;
+using MJCZone.DapperMatic.Models;
+using Xunit.Abstractions;
+
+namespace MJCZone.DapperMatic.Tests;
+
+[DmTable(tableName: "test_ordered_idx")]
+[DmIndex(columnNames: ["col_a", "col_b DESC", "col_c ASC"], indexName: "ix_test_ordered")]
+public class TestOrderedIndex
+{
+    [DmColumn("col_a", isPrimaryKey: true)]
+    public int ColA { get; set; }
+
+    [DmColumn("col_b")]
+    public int ColB { get; set; }
+
+    [DmColumn("col_c")]
+    public int ColC { get; set; }
+}
+
+[DmTable(tableName: "test_ordered_pk")]
+[DmPrimaryKeyConstraint(["id DESC"], "pk_test_ordered")]
+public class TestOrderedPrimaryKey
+{
+    [DmColumn("id")]
+    public int Id { get; set; }
+
+    [DmColumn("name", length: 100)]
+    public string Name { get; set; } = string.Empty;
+}
+
+[DmTable(tableName: "test_ordered_uc")]
+[DmUniqueConstraint(columnNames: ["tenant_id", "email DESC"], constraintName: "ux_test_ordered")]
+public class TestOrderedUniqueConstraint
+{
+    [DmColumn("id", isPrimaryKey: true)]
+    public int Id { get; set; }
+
+    [DmColumn("tenant_id")]
+    public Guid TenantId { get; set; }
+
+    [DmColumn("email", length: 320)]
+    public string Email { get; set; } = string.Empty;
+}
+
+public class TableFactoryOrderedColumnTests : TestBase
+{
+    public TableFactoryOrderedColumnTests(ITestOutputHelper output)
+        : base(output) { }
+
+    [Fact]
+    public void DmIndex_attribute_parses_column_sort_direction()
+    {
+        var table = DmTableFactory.GetTable(typeof(TestOrderedIndex));
+
+        var index = table.Indexes.SingleOrDefault(i =>
+            i.IndexName.Equals("ix_test_ordered", StringComparison.OrdinalIgnoreCase)
+        );
+        Assert.NotNull(index);
+        Assert.Equal(3, index.Columns.Count);
+
+        Assert.Equal("col_a", index.Columns[0].ColumnName);
+        Assert.Equal(DmColumnOrder.Ascending, index.Columns[0].Order);
+
+        Assert.Equal("col_b", index.Columns[1].ColumnName);
+        Assert.Equal(DmColumnOrder.Descending, index.Columns[1].Order);
+
+        Assert.Equal("col_c", index.Columns[2].ColumnName);
+        Assert.Equal(DmColumnOrder.Ascending, index.Columns[2].Order);
+    }
+
+    [Fact]
+    public void DmPrimaryKeyConstraint_attribute_parses_column_sort_direction()
+    {
+        var table = DmTableFactory.GetTable(typeof(TestOrderedPrimaryKey));
+
+        Assert.NotNull(table.PrimaryKeyConstraint);
+        Assert.Single(table.PrimaryKeyConstraint.Columns);
+
+        Assert.Equal("id", table.PrimaryKeyConstraint.Columns[0].ColumnName);
+        Assert.Equal(DmColumnOrder.Descending, table.PrimaryKeyConstraint.Columns[0].Order);
+    }
+
+    [Fact]
+    public void DmUniqueConstraint_attribute_parses_column_sort_direction()
+    {
+        var table = DmTableFactory.GetTable(typeof(TestOrderedUniqueConstraint));
+
+        var uc = table.UniqueConstraints.SingleOrDefault(c =>
+            c.ConstraintName.Equals("ux_test_ordered", StringComparison.OrdinalIgnoreCase)
+        );
+        Assert.NotNull(uc);
+        Assert.Equal(2, uc.Columns.Count);
+
+        Assert.Equal("tenant_id", uc.Columns[0].ColumnName);
+        Assert.Equal(DmColumnOrder.Ascending, uc.Columns[0].Order);
+
+        Assert.Equal("email", uc.Columns[1].ColumnName);
+        Assert.Equal(DmColumnOrder.Descending, uc.Columns[1].Order);
+    }
+}


### PR DESCRIPTION
…ection

DmTableFactory now parses "column DESC"/"column ASC" strings from DmIndex, DmPrimaryKeyConstraint, and DmUniqueConstraint attributes instead of treating them as literal column names. Added unit tests for DmOrderedColumn.Parse and DmTableFactory attribute integration.